### PR TITLE
Upgrade to Codecov node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "codecov",
     "gulp-codecov",
     "code-coverage",
-    "codecov.io",
+    "codecov",
     "gulp"
   ],
   "homepage": "https://github.com/eddiemoore/gulp-codecov.io",


### PR DESCRIPTION
We are depreciating the `codecov.io` package in-favor of the `codecov` package: https://github.com/codecov/codecov-node

Thanks @eddiemoore  :)